### PR TITLE
12.4 fix food online shop process

### DIFF
--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/Main.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/Main.java
@@ -14,6 +14,8 @@ import com.kodilla.good.patterns.challenges.food.online.distribution.repository.
 import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequest;
 import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequestRetriever;
 import com.kodilla.good.patterns.challenges.food.online.distribution.service.ExtraFoodShopOrderService;
+import com.kodilla.good.patterns.challenges.food.online.distribution.units.MapOfUnits;
+import com.kodilla.good.patterns.challenges.food.online.distribution.units.Unit;
 import com.kodilla.good.patterns.challenges.food.online.distribution.user.User;
 import com.kodilla.good.patterns.challenges.online.shop.service.order.ProductOrderProcessor;
 import com.kodilla.good.patterns.challenges.online.shop.request.BuyRequest;
@@ -50,12 +52,11 @@ public class Main {
         Companies companies = new Companies();
 
         System.out.println("================");
-
-        FoodOrderProcessor foodOrderProcessor = new FoodOrderProcessor(
-                new PhoneInformationService(), companies.mapOfCompanies,  new ExtraFoodShopOrderService(), new ExtraFoodShopOrderRepository()
-        );
+        MapOfUnits mapOfUnits = new MapOfUnits();
+        FoodOrderProcessor foodOrderProcessor = new FoodOrderProcessor(mapOfUnits.mapOfCompanyUnits);
         OrderRequestRetriever orderRequestRetriever = new OrderRequestRetriever();
         OrderRequest orderRequest = orderRequestRetriever.retrieveData();
+        foodOrderProcessor.processUnit(orderRequest);
         foodOrderProcessor.process(orderRequest);
 
         System.out.println("================");

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/company/Company.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/company/Company.java
@@ -2,6 +2,7 @@ package com.kodilla.good.patterns.challenges.food.online.distribution.company;
 
 import com.kodilla.good.patterns.challenges.food.online.distribution.product.Product;
 import com.kodilla.good.patterns.challenges.food.online.distribution.service.OrderService;
+import com.kodilla.good.patterns.challenges.online.shop.information.InformationService;
 
 import java.util.List;
 

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/company/ExtraFoodShop.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/company/ExtraFoodShop.java
@@ -1,7 +1,9 @@
 package com.kodilla.good.patterns.challenges.food.online.distribution.company;
 
+import com.kodilla.good.patterns.challenges.food.online.distribution.information.PhoneInformationService;
 import com.kodilla.good.patterns.challenges.food.online.distribution.product.Product;
 import com.kodilla.good.patterns.challenges.food.online.distribution.service.OrderService;
+import com.kodilla.good.patterns.challenges.online.shop.information.InformationService;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/product/Product.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/product/Product.java
@@ -1,5 +1,7 @@
 package com.kodilla.good.patterns.challenges.food.online.distribution.product;
 
+import com.kodilla.good.patterns.challenges.online.shop.information.InformationService;
+
 public class Product {
 
     private String name;

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/Companies.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/Companies.java
@@ -14,23 +14,19 @@ import java.util.Map;
 
 public class Companies {
 
-    public Map<Integer, Company> mapOfCompanies = new HashMap<>();
+    public Map<String, Company> mapOfCompanies = new HashMap<>();
 
     public Companies() {
         ExtraFoodShop extraFoodShop = new ExtraFoodShop();
         HealthyShop healthyShop = new HealthyShop();
         GlutenFreeShop glutenFreeShop = new GlutenFreeShop();
 
-        mapOfCompanies.put(1, extraFoodShop);
-        mapOfCompanies.put(2, healthyShop);
-        mapOfCompanies.put(3, glutenFreeShop);
+        mapOfCompanies.put(ExtraFoodShop.COMPANY_NAME, extraFoodShop);
+        mapOfCompanies.put(HealthyShop.COMPANY_NAME, healthyShop);
+        mapOfCompanies.put(GlutenFreeShop.COMPANY_NAME, glutenFreeShop);
     }
 
-    public Map<Integer, Company> getMapOfCompanies() {
+    public Map<String, Company> getMapOfCompanies() {
         return mapOfCompanies;
-    }
-
-    public Company getCompanyById(int companyId) {
-        return mapOfCompanies.get(companyId);
     }
 }

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/ExtraFoodShopOrderRepository.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/ExtraFoodShopOrderRepository.java
@@ -3,6 +3,7 @@ package com.kodilla.good.patterns.challenges.food.online.distribution.repository
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.Company;
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.ExtraFoodShop;
 import com.kodilla.good.patterns.challenges.food.online.distribution.product.Product;
+import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequest;
 import com.kodilla.good.patterns.challenges.food.online.distribution.user.User;
 
 import java.time.LocalDate;
@@ -15,17 +16,17 @@ public class ExtraFoodShopOrderRepository implements FoodOrderRepository{
     private final Companies companies = new Companies();
 
     @Override
-    public boolean createOrder(User user, LocalDate dateOfCreatingOrder, double price) {
+    public boolean createOrder(OrderRequest orderRequest) {
         System.out.println("Creating an order from:" + ExtraFoodShop.COMPANY_NAME + "\n" +
-                "for: " + user.getFirstName() + user.getLastName() + "\n" +
+                "for: " + orderRequest.getUser().getFirstName() + orderRequest.getUser().getLastName() + "\n" +
                 "Dish chosen: " + returnSpecificDishFromMap(companies) + "\n" +
-                "Date of placing an order: " + dateOfCreatingOrder + "\n" +
-                "Price: " + companies.getCompanyById(1).getProducts().get(0).getPriceTag());
+                "Date of placing an order: " + orderRequest.getDateOfPurchase() + "\n" +
+                "Price: " + orderRequest.getPrice());
         return true;
     }
 
     private String returnSpecificDishFromMap(Companies companies) {
-        Map<Integer, Company> mapOfCompanies = companies.getMapOfCompanies();
+        Map<String, Company> mapOfCompanies = companies.getMapOfCompanies();
 
         String desiredDishName = "Spaghetti";
 

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/FoodOrderRepository.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/FoodOrderRepository.java
@@ -1,10 +1,11 @@
 package com.kodilla.good.patterns.challenges.food.online.distribution.repository;
 
+import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequest;
 import com.kodilla.good.patterns.challenges.food.online.distribution.user.User;
 
 import java.time.LocalDate;
 
 public interface FoodOrderRepository {
 
-    boolean createOrder(User user, LocalDate dateOfCreatingOrder, double price);
+    boolean createOrder(OrderRequest orderRequest);
 }

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/GlutenFreeShopOrderRepository.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/GlutenFreeShopOrderRepository.java
@@ -2,7 +2,9 @@ package com.kodilla.good.patterns.challenges.food.online.distribution.repository
 
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.Company;
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.ExtraFoodShop;
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.GlutenFreeShop;
 import com.kodilla.good.patterns.challenges.food.online.distribution.product.Product;
+import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequest;
 import com.kodilla.good.patterns.challenges.food.online.distribution.user.User;
 
 import java.time.LocalDate;
@@ -13,17 +15,17 @@ public class GlutenFreeShopOrderRepository implements FoodOrderRepository{
 
     private final Companies companies = new Companies();
     @Override
-    public boolean createOrder(User user, LocalDate dateOfCreatingOrder, double price) {
-        System.out.println("Creating an order from:" + ExtraFoodShop.COMPANY_NAME + "\n" +
-                "for: " + user.getFirstName() + user.getLastName() + "\n" +
+    public boolean createOrder(OrderRequest orderRequest) {
+        System.out.println("Creating an order from:" + GlutenFreeShop.COMPANY_NAME + "\n" +
+                "for: " + orderRequest.getUser().getFirstName() + orderRequest.getUser().getLastName() + "\n" +
                 "Dish chosen: " + returnSpecificDishFromMap(companies) + "\n" +
-                "Date of placing an order: " + dateOfCreatingOrder + "\n" +
-                "Price: " + companies.getCompanyById(3).getProducts().get(0).getPriceTag());
+                "Date of placing an order: " + orderRequest.getDateOfPurchase() + "\n" +
+                "Price: " + orderRequest.getPrice());
         return true;
     }
 
     private String returnSpecificDishFromMap(Companies companies) {
-        Map<Integer, Company> mapOfCompanies = companies.getMapOfCompanies();
+        Map<String, Company> mapOfCompanies = companies.getMapOfCompanies();
 
         String desiredDishName = "Rice";
 

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/HealthyShopOrderRepository.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/repository/HealthyShopOrderRepository.java
@@ -2,7 +2,9 @@ package com.kodilla.good.patterns.challenges.food.online.distribution.repository
 
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.Company;
 import com.kodilla.good.patterns.challenges.food.online.distribution.company.ExtraFoodShop;
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.HealthyShop;
 import com.kodilla.good.patterns.challenges.food.online.distribution.product.Product;
+import com.kodilla.good.patterns.challenges.food.online.distribution.request.OrderRequest;
 import com.kodilla.good.patterns.challenges.food.online.distribution.user.User;
 
 import java.time.LocalDate;
@@ -13,17 +15,17 @@ public class HealthyShopOrderRepository implements FoodOrderRepository{
 
     private final Companies companies = new Companies();
     @Override
-    public boolean createOrder(User user, LocalDate dateOfCreatingOrder, double price) {
-        System.out.println("Creating an order from:" + ExtraFoodShop.COMPANY_NAME + "\n" +
-                "for: " + user.getFirstName() + user.getLastName() + "\n" +
+    public boolean createOrder(OrderRequest orderRequest) {
+        System.out.println("Creating an order from:" + HealthyShop.COMPANY_NAME + "\n" +
+                "for: " + orderRequest.getUser().getFirstName() + orderRequest.getUser().getLastName() + "\n" +
                 "Dish chosen: " + returnSpecificDishFromMap(companies) + "\n" +
-                "Date of placing an order: " + dateOfCreatingOrder + "\n" +
-                "Price: " + companies.getCompanyById(2).getProducts().get(0).getPriceTag());
+                "Date of placing an order: " + orderRequest.getDateOfPurchase() + "\n" +
+                "Price: " + orderRequest.getPrice());
         return true;
     }
 
     private String returnSpecificDishFromMap(Companies companies) {
-        Map<Integer, Company> mapOfCompanies = companies.getMapOfCompanies();
+        Map<String, Company> mapOfCompanies = companies.getMapOfCompanies();
 
         String desiredDishName = "Turkey";
 

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/request/OrderRequest.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/request/OrderRequest.java
@@ -12,12 +12,14 @@ public class OrderRequest {
     private LocalDate dateOfPurchase;
     private double price;
     private String food;
+    private String companyName;
 
-    public OrderRequest(User user, LocalDateTime dateOfPurchase, double price, String food) {
+    public OrderRequest(User user, LocalDateTime dateOfPurchase, double price, String food, String companyName) {
         this.user = user;
         this.dateOfPurchase = LocalDate.from(dateOfPurchase);
         this.price = price;
         this.food = food;
+        this.companyName = companyName;
     }
 
     public User getUser() {
@@ -34,5 +36,9 @@ public class OrderRequest {
 
     public String getFood() {
         return food;
+    }
+
+    public String getCompanyName() {
+        return companyName;
     }
 }

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/request/OrderRequestRetriever.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/request/OrderRequestRetriever.java
@@ -17,6 +17,8 @@ public class OrderRequestRetriever {
 
          String food = "Turkey";
 
-         return new OrderRequest(user, localDate.atStartOfDay(), price, food);
+         String companyName = "GlutenFreeShop";
+
+         return new OrderRequest(user, localDate.atStartOfDay(), price, food, companyName);
      }
 }

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/units/MapOfUnits.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/units/MapOfUnits.java
@@ -1,0 +1,31 @@
+package com.kodilla.good.patterns.challenges.food.online.distribution.units;
+
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.Company;
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.ExtraFoodShop;
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.GlutenFreeShop;
+import com.kodilla.good.patterns.challenges.food.online.distribution.company.HealthyShop;
+import com.kodilla.good.patterns.challenges.food.online.distribution.information.PhoneInformationService;
+import com.kodilla.good.patterns.challenges.food.online.distribution.repository.ExtraFoodShopOrderRepository;
+import com.kodilla.good.patterns.challenges.food.online.distribution.repository.GlutenFreeShopOrderRepository;
+import com.kodilla.good.patterns.challenges.food.online.distribution.repository.HealthyShopOrderRepository;
+import com.kodilla.good.patterns.challenges.food.online.distribution.service.ExtraFoodShopOrderService;
+import com.kodilla.good.patterns.challenges.food.online.distribution.service.GlutenFreeShopOrderService;
+import com.kodilla.good.patterns.challenges.food.online.distribution.service.HealthyShopOrderService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapOfUnits {
+
+    public Map<String, Unit> mapOfCompanyUnits = new HashMap<>();
+
+    public MapOfUnits() {
+        mapOfCompanyUnits.put(ExtraFoodShop.COMPANY_NAME,new Unit(new PhoneInformationService(), new ExtraFoodShopOrderRepository(), new ExtraFoodShopOrderService()));
+        mapOfCompanyUnits.put(HealthyShop.COMPANY_NAME,new Unit(new PhoneInformationService(), new HealthyShopOrderRepository(), new HealthyShopOrderService()));
+        mapOfCompanyUnits.put(GlutenFreeShop.COMPANY_NAME,new Unit(new PhoneInformationService(), new GlutenFreeShopOrderRepository(), new GlutenFreeShopOrderService()));
+    }
+
+    public Map<String, Unit> getMapOfCompanyUnits() {
+        return mapOfCompanyUnits;
+    }
+}

--- a/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/units/Unit.java
+++ b/kodilla-good-patterns/src/main/java/com/kodilla/good/patterns/challenges/food/online/distribution/units/Unit.java
@@ -1,0 +1,30 @@
+package com.kodilla.good.patterns.challenges.food.online.distribution.units;
+
+import com.kodilla.good.patterns.challenges.food.online.distribution.information.InformationService;
+import com.kodilla.good.patterns.challenges.food.online.distribution.repository.FoodOrderRepository;
+import com.kodilla.good.patterns.challenges.food.online.distribution.service.OrderService;
+
+public class Unit {
+
+    private InformationService informationService;
+    private FoodOrderRepository foodOrderRepository;
+    private OrderService orderService;
+
+    public Unit(InformationService informationService, FoodOrderRepository foodOrderRepository, OrderService orderService) {
+        this.informationService = informationService;
+        this.foodOrderRepository = foodOrderRepository;
+        this.orderService = orderService;
+    }
+
+    public InformationService getInformationService() {
+        return informationService;
+    }
+
+    public FoodOrderRepository getFoodOrderRepository() {
+        return foodOrderRepository;
+    }
+
+    public OrderService getOrderService() {
+        return orderService;
+    }
+}


### PR DESCRIPTION
I've created a map of Units(Information Service, FoodOrderRepository and OrderService object) and put them into the map. The request now has a company name that search for a key into a map and then return proper unit and that unit goes to the process and creates a order for a food. When user changes the companyName and food the process request uses specific company that have proper food.